### PR TITLE
adds upsert support, handle rules: update=>create

### DIFF
--- a/src/generator/client/clientDb.generate.ts
+++ b/src/generator/client/clientDb.generate.ts
@@ -87,11 +87,11 @@ const *{model}Client = {
     ): PrismaPromise<Prisma.BatchPayload> =>
         // @ts-ignore
         exec({ func: 'updateMany', model: '*{model}', args }),
-    // upsert: <T extends Prisma.*{Model}UpsertArgs>(
-    //     args: Prisma.SelectSubset<T, Prisma.*{Model}UpsertArgs>,
-    // ): Prisma.Prisma__*{Model}Client<Prisma.*{Model}GetPayload<T>> =>
-    //     // @ts-ignore
-    //     exec({ func: 'upsert', model: '*{model}', args }),
+    upsert: <T extends Prisma.*{Model}UpsertArgs>(
+        args: Prisma.SelectSubset<T, Prisma.*{Model}UpsertArgs>,
+    ): Prisma.Prisma__*{Model}Client<Prisma.*{Model}GetPayload<T>> =>
+        // @ts-ignore
+        exec({ func: 'upsert', model: '*{model}', args }),
   };  
   `;
 

--- a/src/generator/server/requestHandler.generate.ts
+++ b/src/generator/server/requestHandler.generate.ts
@@ -1,7 +1,8 @@
 import { writeFileSafely } from '../../utils/file.util';
 import { generateServerTypes } from './serverTypes.generate';
 
-const HANDLER_TEMPLATE = `import { Prisma, PrismaClient } from '@prisma/client';
+const HANDLER_TEMPLATE = `
+import { Prisma, PrismaClient } from '@prisma/client';
 
 export const handleRequest = async (
   requestBody: {
@@ -19,118 +20,33 @@ export const handleRequest = async (
   if (!models.includes(model)) return { status: 401, data: { error: 'Unauthorized', model } };
   args = args || {};
   const { db, uid, rules } = config;
-  const method = FUNC_METHOD_MAP[func];
-
-  const applyRulesWheres = async (
-    args: { where?: any; include?: any; data?: any },
-    options: { model: ModelName; acceptsWheres?: boolean; method: 'find' | 'create' | 'update' | 'delete' },
-  ) => {
-    const { model, acceptsWheres = true, method } = options;
-    const modelMethodValidator = rules[model]?.[method];
-    const modelDefaultValidator = rules[model]?.default;
-    // can't use "a || b || c", bc it would inadvertently skip "method:false" rules
-    const queryValidator = modelMethodValidator ?? modelDefaultValidator ?? !!rules.default;
-    const ruleWhereOrBool =
-      typeof queryValidator === 'function' ? await queryValidator(uid, args?.data) : queryValidator;
-      if (ruleWhereOrBool === false) throw { message: 'Unauthorized', data: { model } };
-      if (typeof ruleWhereOrBool === 'object' && !acceptsWheres) {
-      console.error(
-        \`Rule error on nested model: "\${model}".  Cannot apply prisma where clauses to N-1 or 1-1 required relationships, only 1-N.
-More info: https://github.com/prisma/prisma/issues/15837#issuecomment-1290404982
-
-To fix this until issue is resolved: Change "\${model}" db rules to not rely on where clauses, OR for N-1 relationships, invert the include so the "\${model}" model is including the many table. (N-1 => 1-N)\`,
-      );
-      throw { message: 'Unauthorized', data: { model } };
-      // don't accept wheres for create
-    } else if (method !== 'create') {
-      if (ruleWhereOrBool === true && !acceptsWheres) {
-        delete args.where;
-      } else {
-        const rulesWhere = ruleWhereOrBool === true ? {} : ruleWhereOrBool;
-        // Note: AND: [args.where, rulesWhere] breaks on findUnique, update, delete
-        args.where = { ...(args?.where || {}), AND: [rulesWhere] };
-      }
-    }
-    const modelRelations = MODEL_RELATION_MAP[model];
-    if (args.include) {
-      await Promise.all(
-        Object.keys(args.include).map((relationName: string) => {
-          const m = modelRelations[relationName];
-          const relationInclude = args.include[relationName];
-          if (relationInclude === false) return true;
-          else if (relationInclude === true) {
-            args.include[relationName] = { where: {} };
-            return applyRulesWheres(args.include[relationName], { ...m, method: 'find' });
-          } else {
-            return applyRulesWheres(relationInclude, { ...m, method: 'find' });
-          }
-        }),
-      );
-    }
-
-    // Handle relational data mutations
-    if (args.data && ['create', 'update'].includes(method)) {
-      const relationNames = Object.keys(modelRelations);
-      const relationsInDataProp = Object.keys(args.data).filter((key) => relationNames.includes(key));
-      await Promise.all(
-        relationsInDataProp
-          .map((relationName) => {
-            // mutationMethod: create | connect | connectOrCreate | delete | deleteMany | disconnect
-            // | set | update | updateMany | upsert | push (mongo only)
-            return Object.keys(args.data[relationName]).map(async (mutationMethod) => {
-              // disabled: connectOrCreate, set / disconnect (no wheres), upsert
-              if (!['connect', 'create', 'delete', 'deleteMany', 'update', 'updateMany'].includes(mutationMethod)) {
-                console.error(
-                  \`Nested \${mutationMethod} not yet supported in Bridg. Could violate database rules without further development.\`,
-                );
-                throw Error();
-              }
-              const method =
-                mutationMethod === 'connect' ? 'update' : FUNC_METHOD_MAP[mutationMethod as PrismaFunction];
-              if (!method) throw Error();
-              const mutationMethodValue = args.data[relationName][mutationMethod];
-
-              // diff data input for each nested method, for create/connect, its direct data,
-              // for delete/deleteMany, its a direct where,
-              // for update/updateMany its { where:{}, data:{} }
-              const argType = ['update', 'updateMany'].includes(mutationMethod)
-                ? 'WHERE_AND_DATA'
-                : ['create', 'connect'].includes(mutationMethod)
-                ? 'DATA'
-                : ['delete', 'deleteMany'].includes(mutationMethod)
-                ? 'WHERE'
-                : null;
-              if (!argType) throw Error('invalid argType');
-
-              const nestedArgs = {
-                WHERE_AND_DATA: mutationMethodValue,
-                WHERE: { where: mutationMethodValue },
-                DATA: { data: mutationMethodValue },
-              }[argType];
-
-              await applyRulesWheres(nestedArgs, { ...modelRelations[relationName], method });
-
-              const computedArgs = {
-                WHERE_AND_DATA: nestedArgs,
-                WHERE: nestedArgs.where,
-                DATA: nestedArgs.data,
-              }[argType];
-
-              args.data[relationName][mutationMethod] = computedArgs;
-            });
-          })
-          .flat(),
-      );
-    }
-  };
+  let method = FUNC_METHOD_MAP[func];
 
   try {
-    await applyRulesWheres(args, { model, method });
+    if (func === 'upsert') {
+      const updateArgs = {
+        where: args.where,
+        data: args.update,
+      };
+      await applyRulesWheres(updateArgs, { model, method: 'update' }, { uid, rules });
+      // @ts-expect-error - catch err 'Record to update not found.'
+      const updateData = await db[model].update(updateArgs).catch(() => {});
+      if (updateData) {
+        return { status: 200, data: updateData };
+      } else {
+        // no data updated, continue as a .create query
+        func = 'create';
+        args = { data: args.create };
+        method = 'create';
+      }
+    }
+
+    await applyRulesWheres(args, { model, method }, { uid, rules });
   } catch (err: any) {
     if (err?.message === 'Unauthorized') {
-      return { status: 401, data: { error: \`Unauthorized Bridg query on model: $\{err?.data?.model}\` } };
+      return { status: 401, data: { error: \`Unauthorized Bridg query on model: \${err?.data?.model}\` } };
     } else {
-      return { status: 400, data: { error: \`Error executing Bridg query: $\{err?.message}\` } };
+      return { status: 400, data: { error: \`Error executing Bridg query: \${err?.message}\` } };
     }
   }
 
@@ -144,6 +60,109 @@ To fix this until issue is resolved: Change "\${model}" db rules to not rely on 
   }
 
   return { status: 200, data };
+};
+
+const applyRulesWheres = async (
+  args: { where?: any; include?: any; data?: any },
+  options: { model: ModelName; acceptsWheres?: boolean; method: 'find' | 'create' | 'update' | 'delete' },
+  context: { uid?: string; rules: DbRules },
+) => {
+  const { uid, rules } = context;
+  const { model, acceptsWheres = true, method } = options;
+  const modelMethodValidator = rules[model]?.[method];
+  const modelDefaultValidator = rules[model]?.default;
+  // can't use "a || b || c", bc it would inadvertently skip "method:false" rules
+  const queryValidator = modelMethodValidator ?? modelDefaultValidator ?? !!rules.default;
+  const ruleWhereOrBool = typeof queryValidator === 'function' ? await queryValidator(uid, args?.data) : queryValidator;
+  if (ruleWhereOrBool === false) throw { message: 'Unauthorized', data: { model } };
+  if (typeof ruleWhereOrBool === 'object' && !acceptsWheres) {
+    console.error(
+      \`Rule error on nested model: "\${model}".  Cannot apply prisma where clauses to N-1 or 1-1 required relationships, only 1-N.
+More info: https://github.com/prisma/prisma/issues/15837#issuecomment-1290404982
+
+To fix this until issue is resolved: Change "\${model}" db rules to not rely on where clauses, OR for N-1 relationships, invert the include so the "\${model}" model is including the many table. (N-1 => 1-N)\`,
+    );
+    throw { message: 'Unauthorized', data: { model } };
+    // don't accept wheres for create
+  } else if (method !== 'create') {
+    if (ruleWhereOrBool === true && !acceptsWheres) {
+      delete args.where;
+    } else {
+      const rulesWhere = ruleWhereOrBool === true ? {} : ruleWhereOrBool;
+      // Note: AND: [args.where, rulesWhere] breaks on findUnique, update, delete
+      args.where = { ...(args?.where || {}), AND: [rulesWhere] };
+    }
+  }
+  const modelRelations = MODEL_RELATION_MAP[model];
+  if (args.include) {
+    await Promise.all(
+      Object.keys(args.include).map((relationName: string) => {
+        const m = modelRelations[relationName];
+        const relationInclude = args.include[relationName];
+        if (relationInclude === false) return true;
+        else if (relationInclude === true) {
+          args.include[relationName] = { where: {} };
+          return applyRulesWheres(args.include[relationName], { ...m, method: 'find' }, context);
+        } else {
+          return applyRulesWheres(relationInclude, { ...m, method: 'find' }, context);
+        }
+      }),
+    );
+  }
+
+  // Handle relational data mutations
+  if (args.data && ['create', 'update'].includes(method)) {
+    const relationNames = Object.keys(modelRelations);
+    const relationsInDataProp = Object.keys(args.data).filter((key) => relationNames.includes(key));
+    await Promise.all(
+      relationsInDataProp
+        .map((relationName) => {
+          // mutationMethod: create | connect | connectOrCreate | delete | deleteMany | disconnect
+          // | set | update | updateMany | upsert | push (mongo only)
+          return Object.keys(args.data[relationName]).map(async (mutationMethod) => {
+            // disabled: connectOrCreate, set / disconnect (no wheres), upsert
+            if (!['connect', 'create', 'delete', 'deleteMany', 'update', 'updateMany'].includes(mutationMethod)) {
+              console.error(
+               \`Nested \${mutationMethod} not yet supported in Bridg. Could violate database rules without further development.\`,
+              );
+              throw Error();
+            }
+            const method = mutationMethod === 'connect' ? 'update' : FUNC_METHOD_MAP[mutationMethod as PrismaFunction];
+            if (!method) throw Error();
+            const mutationMethodValue = args.data[relationName][mutationMethod];
+
+            // diff data input for each nested method, for create/connect, its direct data,
+            // for delete/deleteMany, its a direct where,
+            // for update/updateMany its { where:{}, data:{} }
+            const argType = ['update', 'updateMany'].includes(mutationMethod)
+              ? 'WHERE_AND_DATA'
+              : ['create', 'connect'].includes(mutationMethod)
+              ? 'DATA'
+              : ['delete', 'deleteMany'].includes(mutationMethod)
+              ? 'WHERE'
+              : null;
+            if (!argType) throw Error('invalid argType');
+
+            const nestedArgs = {
+              WHERE_AND_DATA: mutationMethodValue,
+              WHERE: { where: mutationMethodValue },
+              DATA: { data: mutationMethodValue },
+            }[argType];
+
+            await applyRulesWheres(nestedArgs, { ...modelRelations[relationName], method }, context);
+
+            const computedArgs = {
+              WHERE_AND_DATA: nestedArgs,
+              WHERE: nestedArgs.where,
+              DATA: nestedArgs.data,
+            }[argType];
+
+            args.data[relationName][mutationMethod] = computedArgs;
+          });
+        })
+        .flat(),
+    );
+  }
 };
 
 const funcOptions = [
@@ -160,9 +179,9 @@ const funcOptions = [
   'groupBy',
   'update',
   'updateMany',
-  // 'upsert',
+  'upsert',
 ] as const;
-type PrismaFunction = typeof funcOptions[number];
+type PrismaFunction = (typeof funcOptions)[number];
 
 const FUNC_METHOD_MAP: { [key in PrismaFunction]: 'find' | 'create' | 'update' | 'delete' } = {
   aggregate: 'find',
@@ -178,8 +197,9 @@ const FUNC_METHOD_MAP: { [key in PrismaFunction]: 'find' | 'create' | 'update' |
   groupBy: 'find',
   update: 'update',
   updateMany: 'update',
-  // upsert: 'update',
-}`;
+  upsert: 'update',
+};
+`;
 
 // Currently this is just a static file with no templating,
 // just generating it now bc its likely we'll need to template it eventually

--- a/src/playground/nextjs/tests/bridg/client-db.ts
+++ b/src/playground/nextjs/tests/bridg/client-db.ts
@@ -78,11 +78,11 @@ const userClient = {
   ): PrismaPromise<Prisma.BatchPayload> =>
     // @ts-ignore
     exec({ func: 'updateMany', model: 'user', args }),
-  // upsert: <T extends Prisma.UserUpsertArgs>(
-  //     args: Prisma.SelectSubset<T, Prisma.UserUpsertArgs>,
-  // ): Prisma.Prisma__UserClient<Prisma.UserGetPayload<T>> =>
-  //     // @ts-ignore
-  //     exec({ func: 'upsert', model: 'user', args }),
+  upsert: <T extends Prisma.UserUpsertArgs>(
+    args: Prisma.SelectSubset<T, Prisma.UserUpsertArgs>,
+  ): Prisma.Prisma__UserClient<Prisma.UserGetPayload<T>> =>
+    // @ts-ignore
+    exec({ func: 'upsert', model: 'user', args }),
 };
 
 const blogClient = {
@@ -145,11 +145,11 @@ const blogClient = {
   ): PrismaPromise<Prisma.BatchPayload> =>
     // @ts-ignore
     exec({ func: 'updateMany', model: 'blog', args }),
-  // upsert: <T extends Prisma.BlogUpsertArgs>(
-  //     args: Prisma.SelectSubset<T, Prisma.BlogUpsertArgs>,
-  // ): Prisma.Prisma__BlogClient<Prisma.BlogGetPayload<T>> =>
-  //     // @ts-ignore
-  //     exec({ func: 'upsert', model: 'blog', args }),
+  upsert: <T extends Prisma.BlogUpsertArgs>(
+    args: Prisma.SelectSubset<T, Prisma.BlogUpsertArgs>,
+  ): Prisma.Prisma__BlogClient<Prisma.BlogGetPayload<T>> =>
+    // @ts-ignore
+    exec({ func: 'upsert', model: 'blog', args }),
 };
 
 const commentClient = {
@@ -213,11 +213,11 @@ const commentClient = {
   ): PrismaPromise<Prisma.BatchPayload> =>
     // @ts-ignore
     exec({ func: 'updateMany', model: 'comment', args }),
-  // upsert: <T extends Prisma.CommentUpsertArgs>(
-  //     args: Prisma.SelectSubset<T, Prisma.CommentUpsertArgs>,
-  // ): Prisma.Prisma__CommentClient<Prisma.CommentGetPayload<T>> =>
-  //     // @ts-ignore
-  //     exec({ func: 'upsert', model: 'comment', args }),
+  upsert: <T extends Prisma.CommentUpsertArgs>(
+    args: Prisma.SelectSubset<T, Prisma.CommentUpsertArgs>,
+  ): Prisma.Prisma__CommentClient<Prisma.CommentGetPayload<T>> =>
+    // @ts-ignore
+    exec({ func: 'upsert', model: 'comment', args }),
 };
 
 export default {

--- a/src/playground/nextjs/tests/bridg/handler.ts
+++ b/src/playground/nextjs/tests/bridg/handler.ts
@@ -16,113 +16,28 @@ export const handleRequest = async (
   if (!models.includes(model)) return { status: 401, data: { error: 'Unauthorized', model } };
   args = args || {};
   const { db, uid, rules } = config;
-  const method = FUNC_METHOD_MAP[func];
-
-  const applyRulesWheres = async (
-    args: { where?: any; include?: any; data?: any },
-    options: { model: ModelName; acceptsWheres?: boolean; method: 'find' | 'create' | 'update' | 'delete' },
-  ) => {
-    const { model, acceptsWheres = true, method } = options;
-    const modelMethodValidator = rules[model]?.[method];
-    const modelDefaultValidator = rules[model]?.default;
-    // can't use "a || b || c", bc it would inadvertently skip "method:false" rules
-    const queryValidator = modelMethodValidator ?? modelDefaultValidator ?? !!rules.default;
-    const ruleWhereOrBool =
-      typeof queryValidator === 'function' ? await queryValidator(uid, args?.data) : queryValidator;
-    if (ruleWhereOrBool === false) throw { message: 'Unauthorized', data: { model } };
-    if (typeof ruleWhereOrBool === 'object' && !acceptsWheres) {
-      console.error(
-        `Rule error on nested model: "${model}".  Cannot apply prisma where clauses to N-1 or 1-1 required relationships, only 1-N.
-More info: https://github.com/prisma/prisma/issues/15837#issuecomment-1290404982
-
-To fix this until issue is resolved: Change "${model}" db rules to not rely on where clauses, OR for N-1 relationships, invert the include so the "${model}" model is including the many table. (N-1 => 1-N)`,
-      );
-      throw { message: 'Unauthorized', data: { model } };
-      // don't accept wheres for create
-    } else if (method !== 'create') {
-      if (ruleWhereOrBool === true && !acceptsWheres) {
-        delete args.where;
-      } else {
-        const rulesWhere = ruleWhereOrBool === true ? {} : ruleWhereOrBool;
-        // Note: AND: [args.where, rulesWhere] breaks on findUnique, update, delete
-        args.where = { ...(args?.where || {}), AND: [rulesWhere] };
-      }
-    }
-    const modelRelations = MODEL_RELATION_MAP[model];
-    if (args.include) {
-      await Promise.all(
-        Object.keys(args.include).map((relationName: string) => {
-          const m = modelRelations[relationName];
-          const relationInclude = args.include[relationName];
-          if (relationInclude === false) return true;
-          else if (relationInclude === true) {
-            args.include[relationName] = { where: {} };
-            return applyRulesWheres(args.include[relationName], { ...m, method: 'find' });
-          } else {
-            return applyRulesWheres(relationInclude, { ...m, method: 'find' });
-          }
-        }),
-      );
-    }
-
-    // Handle relational data mutations
-    if (args.data && ['create', 'update'].includes(method)) {
-      const relationNames = Object.keys(modelRelations);
-      const relationsInDataProp = Object.keys(args.data).filter((key) => relationNames.includes(key));
-      await Promise.all(
-        relationsInDataProp
-          .map((relationName) => {
-            // mutationMethod: create | connect | connectOrCreate | delete | deleteMany | disconnect
-            // | set | update | updateMany | upsert | push (mongo only)
-            return Object.keys(args.data[relationName]).map(async (mutationMethod) => {
-              // disabled: connectOrCreate, set / disconnect (no wheres), upsert
-              if (!['connect', 'create', 'delete', 'deleteMany', 'update', 'updateMany'].includes(mutationMethod)) {
-                console.error(
-                  `Nested ${mutationMethod} not yet supported in Bridg. Could violate database rules without further development.`,
-                );
-                throw Error();
-              }
-              const method =
-                mutationMethod === 'connect' ? 'update' : FUNC_METHOD_MAP[mutationMethod as PrismaFunction];
-              if (!method) throw Error();
-              const mutationMethodValue = args.data[relationName][mutationMethod];
-
-              // diff data input for each nested method, for create/connect, its direct data,
-              // for delete/deleteMany, its a direct where,
-              // for update/updateMany its { where:{}, data:{} }
-              const argType = ['update', 'updateMany'].includes(mutationMethod)
-                ? 'WHERE_AND_DATA'
-                : ['create', 'connect'].includes(mutationMethod)
-                ? 'DATA'
-                : ['delete', 'deleteMany'].includes(mutationMethod)
-                ? 'WHERE'
-                : null;
-              if (!argType) throw Error('invalid argType');
-
-              const nestedArgs = {
-                WHERE_AND_DATA: mutationMethodValue,
-                WHERE: { where: mutationMethodValue },
-                DATA: { data: mutationMethodValue },
-              }[argType];
-
-              await applyRulesWheres(nestedArgs, { ...modelRelations[relationName], method });
-
-              const computedArgs = {
-                WHERE_AND_DATA: nestedArgs,
-                WHERE: nestedArgs.where,
-                DATA: nestedArgs.data,
-              }[argType];
-
-              args.data[relationName][mutationMethod] = computedArgs;
-            });
-          })
-          .flat(),
-      );
-    }
-  };
+  let method = FUNC_METHOD_MAP[func];
 
   try {
-    await applyRulesWheres(args, { model, method });
+    if (func === 'upsert') {
+      const updateArgs = {
+        where: args.where,
+        data: args.update,
+      };
+      await applyRulesWheres(updateArgs, { model, method: 'update' }, { uid, rules });
+      // @ts-expect-error - catch err 'Record to update not found.'
+      const updateData = await db[model].update(updateArgs).catch(() => {});
+      if (updateData) {
+        return { status: 200, data: updateData };
+      } else {
+        // no data updated, continue as a .create query
+        func = 'create';
+        args = { data: args.create };
+        method = 'create';
+      }
+    }
+
+    await applyRulesWheres(args, { model, method }, { uid, rules });
   } catch (err: any) {
     if (err?.message === 'Unauthorized') {
       return { status: 401, data: { error: `Unauthorized Bridg query on model: ${err?.data?.model}` } };
@@ -143,6 +58,109 @@ To fix this until issue is resolved: Change "${model}" db rules to not rely on w
   return { status: 200, data };
 };
 
+const applyRulesWheres = async (
+  args: { where?: any; include?: any; data?: any },
+  options: { model: ModelName; acceptsWheres?: boolean; method: 'find' | 'create' | 'update' | 'delete' },
+  context: { uid?: string; rules: DbRules },
+) => {
+  const { uid, rules } = context;
+  const { model, acceptsWheres = true, method } = options;
+  const modelMethodValidator = rules[model]?.[method];
+  const modelDefaultValidator = rules[model]?.default;
+  // can't use "a || b || c", bc it would inadvertently skip "method:false" rules
+  const queryValidator = modelMethodValidator ?? modelDefaultValidator ?? !!rules.default;
+  const ruleWhereOrBool = typeof queryValidator === 'function' ? await queryValidator(uid, args?.data) : queryValidator;
+  if (ruleWhereOrBool === false) throw { message: 'Unauthorized', data: { model } };
+  if (typeof ruleWhereOrBool === 'object' && !acceptsWheres) {
+    console.error(
+      `Rule error on nested model: "${model}".  Cannot apply prisma where clauses to N-1 or 1-1 required relationships, only 1-N.
+More info: https://github.com/prisma/prisma/issues/15837#issuecomment-1290404982
+
+To fix this until issue is resolved: Change "${model}" db rules to not rely on where clauses, OR for N-1 relationships, invert the include so the "${model}" model is including the many table. (N-1 => 1-N)`,
+    );
+    throw { message: 'Unauthorized', data: { model } };
+    // don't accept wheres for create
+  } else if (method !== 'create') {
+    if (ruleWhereOrBool === true && !acceptsWheres) {
+      delete args.where;
+    } else {
+      const rulesWhere = ruleWhereOrBool === true ? {} : ruleWhereOrBool;
+      // Note: AND: [args.where, rulesWhere] breaks on findUnique, update, delete
+      args.where = { ...(args?.where || {}), AND: [rulesWhere] };
+    }
+  }
+  const modelRelations = MODEL_RELATION_MAP[model];
+  if (args.include) {
+    await Promise.all(
+      Object.keys(args.include).map((relationName: string) => {
+        const m = modelRelations[relationName];
+        const relationInclude = args.include[relationName];
+        if (relationInclude === false) return true;
+        else if (relationInclude === true) {
+          args.include[relationName] = { where: {} };
+          return applyRulesWheres(args.include[relationName], { ...m, method: 'find' }, context);
+        } else {
+          return applyRulesWheres(relationInclude, { ...m, method: 'find' }, context);
+        }
+      }),
+    );
+  }
+
+  // Handle relational data mutations
+  if (args.data && ['create', 'update'].includes(method)) {
+    const relationNames = Object.keys(modelRelations);
+    const relationsInDataProp = Object.keys(args.data).filter((key) => relationNames.includes(key));
+    await Promise.all(
+      relationsInDataProp
+        .map((relationName) => {
+          // mutationMethod: create | connect | connectOrCreate | delete | deleteMany | disconnect
+          // | set | update | updateMany | upsert | push (mongo only)
+          return Object.keys(args.data[relationName]).map(async (mutationMethod) => {
+            // disabled: connectOrCreate, set / disconnect (no wheres), upsert
+            if (!['connect', 'create', 'delete', 'deleteMany', 'update', 'updateMany'].includes(mutationMethod)) {
+              console.error(
+                `Nested ${mutationMethod} not yet supported in Bridg. Could violate database rules without further development.`,
+              );
+              throw Error();
+            }
+            const method = mutationMethod === 'connect' ? 'update' : FUNC_METHOD_MAP[mutationMethod as PrismaFunction];
+            if (!method) throw Error();
+            const mutationMethodValue = args.data[relationName][mutationMethod];
+
+            // diff data input for each nested method, for create/connect, its direct data,
+            // for delete/deleteMany, its a direct where,
+            // for update/updateMany its { where:{}, data:{} }
+            const argType = ['update', 'updateMany'].includes(mutationMethod)
+              ? 'WHERE_AND_DATA'
+              : ['create', 'connect'].includes(mutationMethod)
+              ? 'DATA'
+              : ['delete', 'deleteMany'].includes(mutationMethod)
+              ? 'WHERE'
+              : null;
+            if (!argType) throw Error('invalid argType');
+
+            const nestedArgs = {
+              WHERE_AND_DATA: mutationMethodValue,
+              WHERE: { where: mutationMethodValue },
+              DATA: { data: mutationMethodValue },
+            }[argType];
+
+            await applyRulesWheres(nestedArgs, { ...modelRelations[relationName], method }, context);
+
+            const computedArgs = {
+              WHERE_AND_DATA: nestedArgs,
+              WHERE: nestedArgs.where,
+              DATA: nestedArgs.data,
+            }[argType];
+
+            args.data[relationName][mutationMethod] = computedArgs;
+          });
+        })
+        .flat(),
+    );
+  }
+};
+
 const funcOptions = [
   'aggregate',
   'count',
@@ -157,7 +175,7 @@ const funcOptions = [
   'groupBy',
   'update',
   'updateMany',
-  // 'upsert',
+  'upsert',
 ] as const;
 type PrismaFunction = (typeof funcOptions)[number];
 
@@ -175,7 +193,7 @@ const FUNC_METHOD_MAP: { [key in PrismaFunction]: 'find' | 'create' | 'update' |
   groupBy: 'find',
   update: 'update',
   updateMany: 'update',
-  // upsert: 'update',
+  upsert: 'update',
 };
 
 const MODEL_RELATION_MAP: { [key in ModelName]: { [key: string]: { model: ModelName; acceptsWheres: boolean } } } = {


### PR DESCRIPTION
closes #1 

This PR:

- adds upsert support 
- runs rules for `update`, if no data updated, runs a `.create` query with rules for `create`