### PR TITLE
generate starter rules file if none exists

### DIFF
--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -4,7 +4,10 @@ import path from 'path';
 import * as ts from 'typescript';
 import { compileTsDir } from './compileTsDir';
 import { GENERATOR_NAME, VERSION } from './constants';
-import { generateBridgTsFiles } from './generator/ts-generation';
+import {
+  generateBridgTsFiles,
+  generateRulesFile,
+} from './generator/ts-generation';
 import {
   deleteDirSafely,
   deleteFileSafely,
@@ -34,6 +37,7 @@ generatorHandler({
     cleanupPreviouslyGeneratedFiles(outRoot);
     generateBridgTsFiles(schemaPath, tempDir, api);
     compileBridgFiles(tempDir, tsOutDir, debug);
+    generateRulesFile(options, outRoot);
 
     // move files to desired output location, cleanup temp dir
     await moveDirContentsToDirectory(path.join(tsOutDir, 'client'), outRoot);

--- a/packages/generator/src/utils/file.util.ts
+++ b/packages/generator/src/utils/file.util.ts
@@ -106,3 +106,23 @@ export const formatFile = (content: string): Promise<string> => {
     })
   );
 };
+
+export const getRelativePathWithLeadingDot = (
+  sourceFile: string,
+  targetFile: string
+) => {
+  const sourceDir = path.dirname(sourceFile);
+  const loc = path.relative(sourceDir, targetFile);
+  // x/y/z => ./x/y/z
+  return loc.startsWith('.') ? loc : `./${loc}`;
+};
+
+export const getRelativeImportPath = (
+  sourceFile: string,
+  targetFile: string
+) => {
+  const location = getRelativePathWithLeadingDot(sourceFile, targetFile);
+  const [beforeNM, afterNM] = location.split('node_modules/');
+  // ./x/y/node_modules/z => z || ./x/y/z => ./x/y/z
+  return afterNM || beforeNM;
+};

--- a/packages/usage/prisma/bridg/index.js
+++ b/packages/usage/prisma/bridg/index.js
@@ -82,4 +82,4 @@ var bridg = {
     blog: blogClient,
     comment: commentClient,
 };
-exports.default = bridg; //kekw
+exports.default = bridg;

--- a/packages/usage/prisma/rules.ts
+++ b/packages/usage/prisma/rules.ts
@@ -1,0 +1,27 @@
+import { DbRules } from './bridg/server/request-handler';
+
+// https://github.com/joeroddy/bridg#database-rules
+export const rules: DbRules = {
+  // global default, allow/block non-specified queries, set to true only in development
+  default: false, 
+  // tableName: false | true,       - block/allow all queries on a table
+	user: {
+    // find: (uid) => ({ id: uid }) - query based authorization
+		find: (uid) => false,
+    update: (uid, data) => false,
+    create: (uid, data) => false,
+    delete: (uid) => false,
+  },
+	blog: {
+    find: (uid) => false,
+    update: (uid, data) => false,
+    create: (uid, data) => false,
+    delete: (uid) => false,
+  },
+	comment: {
+    find: (uid) => false,
+    update: (uid, data) => false,
+    create: (uid, data) => false,
+    delete: (uid) => false,
+  },
+};


### PR DESCRIPTION
This PR:

- closes #37 
- adds a step to the generator to create an example `rules.ts` file next to the prisma schema, if one doesn't exist
- example rules are based on the models from the user's prisma schema

Example output:
```ts
import { DbRules } from './bridg/server/request-handler';

// https://github.com/joeroddy/bridg#database-rules
export const rules: DbRules = {
  // global default, allow/block non-specified queries, set to true only in development
  default: false, 
  // tableName: false | true,       - block/allow all queries on a table
  user: {
    // find: (uid) => ({ id: uid }) - query based authorization
    find: (uid) => false,
    update: (uid, data) => false,
    create: (uid, data) => false,
    delete: (uid) => false,
  },
};
```