### PR TITLE
Bri 1 pulse support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@ build
 pnpm-debug.log
 .env*
 .DS_Store
+dev.db
 
-# some random testing crap
+# random testing crap
 /packages/usage/output
 /packages/usage/custom-output
 /packages/usage/__tests__/generated

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pnpm-debug.log
 /packages/usage/__tests__/generated
 /packages/usage/prisma/prisma
 /packages/usage/prisma/bridg
+/packages/usage/temp

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dev.db
 /packages/usage/prisma/prisma
 /packages/usage/prisma/bridg
 /packages/usage/temp
+/packages/usage/prisma/bridg_tmp

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bridg",
   "description": "Query your database from any JavaScript frontend",
-  "version": "1.1.1-alpha.1",
+  "version": "1.1.1-alpha.6",
   "license": "ISC",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bridg",
   "description": "Query your database from any JavaScript frontend",
-  "version": "1.1.0",
+  "version": "1.1.1-alpha.1",
   "license": "ISC",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/generator/src/generator/client/config.generate.ts
+++ b/packages/generator/src/generator/client/config.generate.ts
@@ -19,6 +19,7 @@ const bridgConfig = {
     debug: ${debug},
     output: ${output ? `'${output}'` : `undefined`},
     api: ${api ? `'${api}'` : `undefined`},
+    apiIsWebsocket: ${api?.startsWith('ws:') || api?.startsWith('wss:')},
 } as const;
   
 export default bridgConfig;

--- a/packages/generator/src/generator/client/config.generate.ts
+++ b/packages/generator/src/generator/client/config.generate.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+import { writeFileSafely } from '../../utils/file.util';
+
+export type BridgConfigOptions = {
+  pulse?: boolean;
+  debug?: boolean;
+  output?: string;
+  api?: string;
+};
+
+const getConfigFileContent = ({
+  pulse = false,
+  debug = false,
+  output,
+  api = '/api/bridg',
+}: BridgConfigOptions) => `
+const bridgConfig = {
+    pulseEnabled: ${pulse},
+    debug: ${debug},
+    output: ${output ? `'${output}'` : `undefined`},
+    api: ${api ? `'${api}'` : `undefined`},
+} as const;
+  
+export default bridgConfig;
+`;
+
+export const generateBridgConfigFile = ({
+  bridgConfig,
+  outputLocation,
+}: {
+  bridgConfig: BridgConfigOptions;
+  outputLocation: string;
+}) => {
+  const fileContent = getConfigFileContent(bridgConfig);
+  const filePath = path.join(outputLocation, 'bridg.config.ts');
+  writeFileSafely(filePath, fileContent);
+
+  return fileContent;
+};

--- a/packages/generator/src/generator/server/requestHandler.generate.ts
+++ b/packages/generator/src/generator/server/requestHandler.generate.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { BridgConfigOptions } from 'src/generator/client/config.generate';
 import { getRelativeImportPath, writeFileSafely } from '../../utils/file.util';
 
 const HANDLER_TEMPLATE = `
@@ -15,17 +16,22 @@ export const handleRequest = async (
     db: PrismaClient;
     rules: DbRules;
     uid?: string;
+    onSubscriptionCreated?: (sub: any) => void;
+    onSubscriptionEvent?: (args: any) => void;
   }
 ) => {
   const typedClient = withTypename(config.db);
 
+  const { db, uid, rules, onSubscriptionEvent, onSubscriptionCreated } = config;
   let { model, func, args } = requestBody;
-  const originalQuery = deepClone(args);
-  if (!models.includes(model)) return { status: 401, data: { error: 'Unauthorized', model } };
   args = args || {};
-  const { db, uid, rules } = config;
-  let method = FUNC_METHOD_MAP[func];
+  if (!models.includes(model)) return { status: 401, data: { error: 'Unauthorized', model } };
+  if (func === 'subscribe' && !onSubscriptionEvent)
+    return { status: 500, data: { error: 'Subscribe callback not supplied', model } };
 
+  const originalQuery = deepClone(args);
+
+  let method = FUNC_METHOD_MAP[func];
   try {
     if (func === 'upsert') {
       const updateArgs = {
@@ -43,7 +49,6 @@ export const handleRequest = async (
         method = 'create';
       }
     }
-
     await applyRulesWheres(args, { model, method }, { uid, rules });
   } catch (err: any) {
     if (err?.message === 'Unauthorized') {
@@ -63,12 +68,26 @@ export const handleRequest = async (
 
   let cleanedData;
   let queryArgs;
+  let data;
   try {
     const beforeHook = rules[model]?.[method]?.before;
     queryArgs = beforeHook ? beforeHook(uid, args, { method: func, originalQuery }) : args;
 
-    const data = await typedClient[model][func](queryArgs);
-    cleanedData = stripBlockedFields(data, rules);
+    if (func === 'subscribe') {
+      const subscribeArgs = buildSubscribeArgs(queryArgs);
+      const subscription = await db[model][func](subscribeArgs);
+      onSubscriptionCreated?.(subscription);
+      if (subscription instanceof Error) onSubscriptionEvent({ error: subscription });
+      for await (const event of subscription) {
+        const dataKey = 'before' in event ? 'before' : 'after';
+        const cleanedData = stripBlockedFields({ $kind: model, ...event[dataKey] }, rules);
+        onSubscriptionEvent({ ...event, [dataKey]: cleanedData });
+      }
+      return;
+    } else {
+      data = await typedClient[model][func](queryArgs);
+      cleanedData = stripBlockedFields(data, rules);
+    }
   } catch (error) {
     console.error(error);
     return { status: 500, message: 'Internal server error.' };
@@ -267,6 +286,29 @@ const stripBlockedFields = (data: {} | any[], rules: DbRules): any => {
   return deleteBlockedFieldsFromObj(data);
 };
 
+const asArray = (item: Array | any) => (Array.isArray(item) ? item : [item]);
+const buildSubscribeArgs = (queryArgs: {
+  where: {};
+  update?: { after: {} };
+  create?: { after: {} };
+  delete?: { before: {} };
+}) => {
+  const where = queryArgs.where;
+  const subscribeArgs = {};
+  ['create', 'update', 'delete'].forEach((method) => {
+    const key = method === 'delete' ? 'before' : 'after';
+    let userQuery = queryArgs[method]?.[key];
+    if (!userQuery) return;
+    const queryWithRules = {
+      ...userQuery,
+      AND: [...(where?.AND || []), ...asArray(userQuery.AND || [])],
+    };
+
+    subscribeArgs[method] = { [key]: queryWithRules };
+  });
+  return subscribeArgs;
+};
+
 const funcOptions = [
   'aggregate',
   'count',
@@ -282,6 +324,8 @@ const funcOptions = [
   'update',
   'updateMany',
   'upsert',
+  // pulse only
+  'subscribe',
 ] as const;
 type PrismaFunction = typeof funcOptions[number];
 
@@ -302,6 +346,8 @@ const FUNC_METHOD_MAP: {
   update: 'update',
   updateMany: 'update',
   upsert: 'update',
+  // pulse only
+  subscribe: 'find',
 };
 
 const withTypename = Prisma.defineExtension((client) => {
@@ -331,21 +377,37 @@ const deepClone = (obj, seen = new WeakMap()) => {
 };
 `;
 
-const generateHandlerFile = ({
+const getPulseExports = (withPulse: boolean) =>
+  withPulse
+    ? `
+const withPulseClient = (client: PrismaClient, apiKey) => client.$extends(withPulse({ apiKey }));
+export type PulseSubscribe<M extends ModelName> = ReturnType<
+  typeof withPulseClient
+>[M]['subscribe'];`
+    : `export type PulseSubscribe<T> = undefined;`;
+
+export const generateHandlerFile = ({
+  bridgConfig,
   outputLocation,
   prismaLocation = `@prisma/client`,
 }: {
+  bridgConfig: BridgConfigOptions;
   outputLocation: string;
   prismaLocation?: string;
 }) => {
+  const withPulse = !!bridgConfig.pulse;
   const handlerPath = path.join(outputLocation, 'server', 'request-handler.ts');
   const prismaImportPath = prismaLocation
     ? getRelativeImportPath(handlerPath, prismaLocation)
     : `@prisma/client`;
-  const fileContent = `// @ts-nocheck\nimport { Prisma, PrismaClient } from '${prismaImportPath}';${HANDLER_TEMPLATE}`;
+
+  const fileContent = `// @ts-nocheck
+  import { Prisma, PrismaClient } from '${prismaImportPath}';
+  ${withPulse ? `import { withPulse } from '@prisma/extension-pulse';` : ''}
+  ${HANDLER_TEMPLATE}
+  ${getPulseExports(withPulse)}`;
+
   writeFileSafely(handlerPath, fileContent);
 
   return fileContent;
 };
-
-export default generateHandlerFile;

--- a/packages/generator/src/generator/server/requestHandler.generate.ts
+++ b/packages/generator/src/generator/server/requestHandler.generate.ts
@@ -293,15 +293,16 @@ const buildSubscribeArgs = (queryArgs: {
   create?: { after: {} };
   delete?: { before: {} };
 }) => {
+  const applyRuleToAll = !queryArgs.update && !queryArgs.create && !queryArgs.delete;
   const where = queryArgs.where;
   const subscribeArgs = {};
   ['create', 'update', 'delete'].forEach((method) => {
     const key = method === 'delete' ? 'before' : 'after';
-    let userQuery = queryArgs[method]?.[key];
-    if (!userQuery) return;
+    let userQuery = queryArgs[method]?.[key] || queryArgs[method];
+    if (!userQuery && !applyRuleToAll) return;
     const queryWithRules = {
       ...userQuery,
-      AND: [...(where?.AND || []), ...asArray(userQuery.AND || [])],
+      AND: [...(where?.AND || []), ...asArray(userQuery?.AND || [])],
     };
 
     subscribeArgs[method] = { [key]: queryWithRules };

--- a/packages/generator/src/generator/ts-generation.ts
+++ b/packages/generator/src/generator/ts-generation.ts
@@ -66,7 +66,7 @@ export const generateRulesFile = (options: GeneratorOptions, outputRoot: string)
   const rulesLocation = path.join(options.schemaPath, '..', 'rules.ts');
   const modelNames = options.dmmf.datamodel.models.map((m) => m.name);
   if (!modelNames.length || existsSync(rulesLocation)) return;
-  const importPath = getRelativeImportPath(rulesLocation, `${outputRoot}/server/request-handler`);
+  const importPath = getRelativeImportPath(rulesLocation, `${outputRoot}/request-handler`);
   const rulesFileContent = `import { DbRules } from '${importPath}';
 
 // https://github.com/joeroddy/bridg#database-rules

--- a/packages/generator/src/generator/ts-generation.ts
+++ b/packages/generator/src/generator/ts-generation.ts
@@ -10,8 +10,9 @@ import {
 } from '../utils/file.util';
 import { uncapitalize } from '../utils/string.util';
 import { generateClientDbFile } from './client/clientDb.generate';
+import { BridgConfigOptions, generateBridgConfigFile } from './client/config.generate';
 import { generateModelRelationsFile } from './server/modelRelations.generate';
-import generateHandler from './server/requestHandler.generate';
+import { generateHandlerFile } from './server/requestHandler.generate';
 import { generateServerIndexTypesFile } from './server/serverTypes.generate';
 
 export const MODEL_REGEX = /(?<=model\s)\w+(?=\s?{)/gis;
@@ -23,23 +24,23 @@ export const generateBridgTsFiles = (options: GeneratorOptions, outputLocation: 
     schemaStr: readFileAsString(options.schemaPath),
     modelNames: options.dmmf.datamodel.models.map((m) => m.name),
     outputLocation,
-    apiLocation: (options.generator.config.api as string) || '/api/bridg',
     prismaLocation:
       options.otherGenerators.find((g) => g.name === 'client')?.output?.value || undefined,
+    bridgConfig: options.generator.config as BridgConfigOptions,
   });
 
 export const generateFiles = ({
   schemaStr,
   modelNames,
   outputLocation,
-  apiLocation,
   prismaLocation,
+  bridgConfig = {},
 }: {
   schemaStr: string;
   modelNames: string[];
   outputLocation: string;
-  apiLocation: string;
   prismaLocation?: string;
+  bridgConfig?: BridgConfigOptions;
 }) => {
   if (!schemaStr) throw new Error(`Schema not provided`);
   //   if (!schemaStr.match(/.+["']extendedWhereUnique["'].+/g)) {
@@ -53,11 +54,12 @@ export const generateFiles = ({
 
   schemaStr = strip(schemaStr);
 
-  generateClientDbFile({ modelNames, outputLocation, apiLocation, prismaLocation });
+  generateClientDbFile({ modelNames, outputLocation, prismaLocation });
   // server
-  generateHandler({ outputLocation, prismaLocation });
+  generateHandlerFile({ bridgConfig, outputLocation, prismaLocation });
   generateModelRelationsFile({ modelNames, schemaStr, outputLocation });
   generateServerIndexTypesFile({ modelNames, outputLocation, prismaLocation });
+  generateBridgConfigFile({ bridgConfig, outputLocation });
 };
 
 export const generateRulesFile = (options: GeneratorOptions, outputRoot: string) => {

--- a/packages/generator/src/generator/ts-generation.ts
+++ b/packages/generator/src/generator/ts-generation.ts
@@ -66,7 +66,7 @@ export const generateRulesFile = (options: GeneratorOptions, outputRoot: string)
   const rulesLocation = path.join(options.schemaPath, '..', 'rules.ts');
   const modelNames = options.dmmf.datamodel.models.map((m) => m.name);
   if (!modelNames.length || existsSync(rulesLocation)) return;
-  const importPath = getRelativeImportPath(rulesLocation, `${outputRoot}/request-handler`);
+  const importPath = getRelativeImportPath(rulesLocation, `${outputRoot}/server`);
   const rulesFileContent = `import { DbRules } from '${importPath}';
 
 // https://github.com/joeroddy/bridg#database-rules

--- a/packages/usage/__tests__/__fixtures__/pulse-test.prisma
+++ b/packages/usage/__tests__/__fixtures__/pulse-test.prisma
@@ -1,0 +1,51 @@
+generator client {
+    provider = "prisma-client-js"
+    output   = "../generated/prisma-pulse"
+}
+
+generator bridg {
+    provider = "bridg"
+    output   = "../generated/bridg-pulse"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}
+
+model User {
+    id    String  @id @default(cuid())
+    name  String?
+    email String? @unique
+    image String?
+
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+    blogs     Blog[]
+}
+
+model Blog {
+    id    String  @id @default(cuid())
+    title String
+    body  String?
+
+    published Boolean   @default(false)
+    viewCount Int       @default(0)
+    user      User?     @relation(fields: [userId], references: [id])
+    userId    String?
+    comments  Comment[]
+
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+}
+
+model Comment {
+    body String
+
+    blogId String?
+    blog   Blog?   @relation(fields: [blogId], references: [id])
+
+    id        String   @id @default(cuid())
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+}

--- a/packages/usage/__tests__/pulse.test.ts
+++ b/packages/usage/__tests__/pulse.test.ts
@@ -1,0 +1,174 @@
+import http from 'http';
+import { withPulse } from '../node_modules/@prisma/extension-pulse/dist/cjs/index';
+import { handleRequest } from './generated/bridg-pulse/server/request-handler';
+import { PrismaClient } from './generated/prisma-pulse';
+
+jest.setTimeout(30000);
+
+const sleep = (seconds: number) => new Promise((res) => setTimeout(res, seconds * 1000));
+
+const prisma = new PrismaClient().$extends(
+  withPulse({ apiKey: process.env.PULSE_API_KEY! })
+) as unknown as PrismaClient;
+
+let subscriptions: any[] = [];
+const closeSubscriptions = () => subscriptions.forEach((s) => s?.stop());
+
+beforeAll(async () => {
+  // i work on hotspot sometimes.. so yeah..
+  const isConnected = await isInternetConnected();
+  if (!isConnected) throw new Error('No internet connection');
+});
+
+beforeEach(async () => {
+  await prisma.user.deleteMany();
+});
+
+const FAKE_USER_EMAIL = 'newuser@gmail.com';
+
+const createPulseListener = (
+  request: {
+    model: Parameters<typeof handleRequest>[0]['model'];
+    args?: any;
+    rules?: Parameters<typeof handleRequest>[1]['rules'];
+    uid?: string;
+  },
+  pulseCallback: (data: any) => void
+) =>
+  handleRequest(
+    { func: 'subscribe', model: request.model, args: request.args || {} },
+    {
+      rules: request.rules || { default: true },
+      uid: request.uid || '',
+      db: prisma,
+      onSubscriptionEvent: (event) => pulseCallback(event),
+      onSubscriptionCreated: (subscription) => subscriptions.push(subscription),
+    }
+  );
+
+const runCreateUpdateDelete = async () => {
+  await sleep(0.5);
+  const userCreated = await prisma.user.create({ data: { email: FAKE_USER_EMAIL } });
+  await prisma.user.update({ where: { id: userCreated.id }, data: { name: 'john' } });
+  await prisma.user.delete({ where: { id: userCreated.id } });
+  await sleep(3);
+};
+
+it('subscribe emits on creation, update, delete events', async () => {
+  const callbacksHit: string[] = [];
+  createPulseListener({ model: 'user' }, (newData) => callbacksHit.push(newData.action));
+
+  await runCreateUpdateDelete();
+
+  expect(callbacksHit.includes('create')).toBe(true);
+  expect(callbacksHit.includes('update')).toBe(true);
+  expect(callbacksHit.includes('delete')).toBe(true);
+  expect(callbacksHit.length).toBe(3);
+});
+
+it('false rules prevent reading with pulse', async () => {
+  let eventsEmitted = 0;
+
+  const res = await createPulseListener(
+    { model: 'user', rules: { user: { default: false } } },
+    () => eventsEmitted++
+  );
+
+  await runCreateUpdateDelete();
+
+  expect(res.status).toBe(401);
+  expect(eventsEmitted).toBe(0);
+  closeSubscriptions();
+});
+
+it('true rules allow reading with pulse', async () => {
+  let eventsEmitted = 0;
+  createPulseListener({ model: 'user', rules: { user: { default: true } } }, () => eventsEmitted++);
+  await runCreateUpdateDelete();
+  expect(eventsEmitted).toBe(3);
+});
+
+it('where clause rules prevent reading inaccessible data ', async () => {
+  let eventsEmitted: string[] = [];
+
+  createPulseListener(
+    { model: 'user', rules: { user: { find: { email: 'nonmatch@gmail.com' } } } },
+    (e) => eventsEmitted.push(e.action)
+  );
+
+  await runCreateUpdateDelete();
+
+  expect(eventsEmitted.length).toBe(0);
+  closeSubscriptions();
+});
+
+it('where clauses allow reading accessible data', async () => {
+  let eventsEmitted: string[] = [];
+
+  createPulseListener(
+    {
+      model: 'user',
+      args: {
+        create: {},
+        update: {},
+      },
+      rules: { user: { find: { email: FAKE_USER_EMAIL } } },
+    },
+    (e) => eventsEmitted.push(e.action)
+  );
+  await runCreateUpdateDelete();
+  expect(eventsEmitted.length).toBe(2);
+  expect(eventsEmitted.includes('create')).toBe(true);
+  expect(eventsEmitted.includes('update')).toBe(true);
+});
+
+it('user defined filters working with where clauses', async () => {
+  let eventsEmitted: string[] = [];
+
+  createPulseListener(
+    {
+      model: 'user',
+      args: { create: { name: 'fake' }, delete: { before: { name: 'john' } } },
+      rules: { user: { find: { email: FAKE_USER_EMAIL } } },
+    },
+    (e) => eventsEmitted.push(e.action)
+  );
+  await runCreateUpdateDelete();
+  expect(eventsEmitted.length).toBe(1);
+  expect(eventsEmitted.includes('delete')).toBe(true);
+});
+
+it('cannot run pulse queries against relational rules', async () => {
+  let eventsEmitted = [];
+
+  const res = await createPulseListener(
+    {
+      model: 'user',
+      args: { create: { name: 'fake' }, delete: { before: { name: 'john' } } },
+      rules: { user: { find: { email: FAKE_USER_EMAIL, blogs: { some: { title: 'hi' } } } } },
+    },
+    (e) => eventsEmitted.push(e.action)
+  );
+  await runCreateUpdateDelete();
+  expect(res.status).toBe(500);
+  expect(eventsEmitted.length).toBe(0);
+});
+
+afterEach(() => {
+  closeSubscriptions();
+});
+
+afterAll(async () => {
+  prisma.$disconnect();
+  closeSubscriptions();
+});
+
+function isInternetConnected() {
+  return new Promise((resolve) => {
+    http
+      .get('http://www.google.com', (res) =>
+        resolve(res?.statusCode && res.statusCode >= 200 && res.statusCode < 300)
+      )
+      .on('error', () => resolve(false));
+  });
+}

--- a/packages/usage/package.json
+++ b/packages/usage/package.json
@@ -23,6 +23,7 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "@prisma/client": "5.5.2"
+    "@prisma/client": "5.5.2",
+    "@prisma/extension-pulse": "^0.1.8"
   }
 }

--- a/packages/usage/package.json
+++ b/packages/usage/package.json
@@ -5,7 +5,9 @@
   "main": "src/app.js",
   "license": "MIT",
   "scripts": {
-    "test:prepare": "cd ../generator && npm run prepack && cd ../usage && npx prisma db push --schema=__tests__/__fixtures__/test.prisma;",
+    "test:prepare": "npm run test:prepare-base && npm run test:prepare-pulse",
+    "test:prepare-base": "pnpm --F bridg -- npm run prepack && npx prisma db push --schema=__tests__/__fixtures__/test.prisma;",
+    "test:prepare-pulse": "pnpm --F bridg -- npm run prepack && npx prisma db push --schema=__tests__/__fixtures__/pulse-test.prisma;",
     "test": "jest --runInBand",
     "test:prisma-versions": "npx ts-node ./scripts/test-prisma-versions.ts",
     "prisma:install": "pnpm i -D prisma@$VERSION && pnpm i @prisma/client@$VERSION",

--- a/packages/usage/package.json
+++ b/packages/usage/package.json
@@ -9,6 +9,7 @@
     "test:prepare-base": "pnpm --F bridg -- npm run prepack && npx prisma db push --schema=__tests__/__fixtures__/test.prisma;",
     "test:prepare-pulse": "pnpm --F bridg -- npm run prepack && npx prisma db push --schema=__tests__/__fixtures__/pulse-test.prisma;",
     "test": "jest --runInBand",
+    "test:base": "jest --testPathPattern='^(?!.*pulse.test.ts$).*.test.ts$' --runInBand",
     "test:prisma-versions": "npx ts-node ./scripts/test-prisma-versions.ts",
     "prisma:install": "pnpm i -D prisma@$VERSION && pnpm i @prisma/client@$VERSION",
     "prisma:versions": "npm view prisma versions | grep -v '-'"

--- a/packages/usage/prisma/rules.ts
+++ b/packages/usage/prisma/rules.ts
@@ -1,24 +1,24 @@
-import { DbRules } from './bridg/server/request-handler';
+import { DbRules } from './bridg/server';
 
 // https://github.com/joeroddy/bridg#database-rules
 export const rules: DbRules = {
   // global default, allow/block non-specified queries, set to true only in development
-  default: false, 
+  default: false,
   // tableName: false | true,       - block/allow all queries on a table
-	user: {
+  user: {
     // find: (uid) => ({ id: uid }) - query based authorization
-		find: (uid) => false,
-    update: (uid, data) => false,
-    create: (uid, data) => false,
-    delete: (uid) => false,
-  },
-	blog: {
     find: (uid) => false,
     update: (uid, data) => false,
     create: (uid, data) => false,
     delete: (uid) => false,
   },
-	comment: {
+  blog: {
+    find: (uid) => false,
+    update: (uid, data) => false,
+    create: (uid, data) => false,
+    delete: (uid) => false,
+  },
+  comment: {
     find: (uid) => false,
     update: (uid, data) => false,
     create: (uid, data) => false,

--- a/packages/usage/prisma/schema.prisma
+++ b/packages/usage/prisma/schema.prisma
@@ -6,11 +6,15 @@ generator client {
 generator bridg {
   provider = "bridg"
   output   = "./bridg"
+  // pulse    = true
+  // api      = "ws://localhost:3000"
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = "file:./dev.db"
+  // provider = "sqlite"
+  // url      = "file:./dev.db"
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model User {

--- a/packages/usage/scripts/test-prisma-versions.ts
+++ b/packages/usage/scripts/test-prisma-versions.ts
@@ -31,13 +31,13 @@ export const prepareEnv = async (prismaVersion: string) => {
   execSyncNoOut(`VERSION=${prismaVersion} npm run prisma:install`);
   console.log('client installed');
 
-  execSyncNoOut(`npm run test:prepare`);
+  execSyncNoOut(`npm run test:prepare-base`);
   console.log('schema pushed, client generated');
 
   console.log('starting tests...');
 
   try {
-    execSyncNoOut(`npm run test`);
+    execSyncNoOut(`npm run test:base`);
   } catch (err) {
     console.log('Tests failed.');
     failed.push(prismaVersion);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,8 @@ importers:
 
   packages/usage/__tests__/generated/prisma: {}
 
+  packages/usage/__tests__/generated/prisma-pulse: {}
+
   packages/usage/prisma/prisma: {}
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 2.4.2
       jest:
         specifier: 27.4.7
-        version: 27.4.7(ts-node@10.9.1)
+        version: 27.4.7
       semantic-release:
         specifier: ^18.0.1
         version: 18.0.1
@@ -72,6 +72,9 @@ importers:
       '@prisma/client':
         specifier: 5.5.2
         version: 5.5.2(prisma@5.5.2)
+      '@prisma/extension-pulse':
+        specifier: ^0.1.8
+        version: 0.1.8(@prisma/client@5.5.2)
     devDependencies:
       '@jest/globals':
         specifier: ^29.6.2
@@ -647,6 +650,51 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /@jest/core@27.5.1:
+    resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 27.5.1
+      '@jest/reporters': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
+      '@types/node': 17.0.21
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 27.5.1
+      jest-config: 27.5.1
+      jest-haste-map: 27.5.1
+      jest-message-util: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-resolve-dependencies: 27.5.1
+      jest-runner: 27.5.1
+      jest-runtime: 27.5.1
+      jest-snapshot: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      jest-watcher: 27.5.1
+      micromatch: 4.0.5
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
   /@jest/core@27.5.1(ts-node@10.9.1):
     resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -1144,6 +1192,18 @@ packages:
   /@prisma/engines@5.5.2:
     resolution: {integrity: sha512-Be5hoNF8k+lkB3uEMiCHbhbfF6aj1GnrTBnn5iYFT7GEr3TsOEp1soviEcBR0tYCgHbxjcIxJMhdbvxALJhAqg==}
     requiresBuild: true
+
+  /@prisma/extension-pulse@0.1.8(@prisma/client@5.5.2):
+    resolution: {integrity: sha512-oWOldt1uJSuAVOws1T8QP13n8qH5agaIdcMfHK44/+VRJXAu/cKZt9y7iNx1K8FtgezCaszRXlLgkE5Yf4VDmQ==}
+    peerDependencies:
+      '@prisma/client': '>=4.16.1'
+    dependencies:
+      '@prisma/client': 5.5.2(prisma@5.5.2)
+      ws: 8.14.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
 
   /@prisma/generator-helper@5.1.0:
     resolution: {integrity: sha512-N/6nE76YFByywR5tTScevPJGfbftdRbANPlTsL5KvpJWnnLPBvNZCtGpto2Ax4Ot15zLA0/olql5609X2zzXcg==}
@@ -2857,6 +2917,36 @@ packages:
       - supports-color
     dev: true
 
+  /jest-cli@27.5.1:
+    resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/types': 27.5.1
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.1.0
+      jest-config: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      prompts: 2.4.2
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
   /jest-cli@27.5.1(ts-node@10.9.1):
     resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2884,6 +2974,46 @@ packages:
       - canvas
       - supports-color
       - ts-node
+      - utf-8-validate
+    dev: true
+
+  /jest-config@27.5.1:
+    resolution: {integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.9
+      '@jest/test-sequencer': 27.5.1
+      '@jest/types': 27.5.1
+      babel-jest: 27.5.1(@babel/core@7.22.9)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 27.5.1
+      jest-environment-jsdom: 27.5.1
+      jest-environment-node: 27.5.1
+      jest-get-type: 27.5.1
+      jest-jasmine2: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-runner: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 27.5.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
       - utf-8-validate
     dev: true
 
@@ -3388,6 +3518,27 @@ packages:
       jest-util: 29.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: true
+
+  /jest@27.4.7:
+    resolution: {integrity: sha512-8heYvsx7nV/m8m24Vk26Y87g73Ba6ueUd0MWed/NXMhSZIm62U/llVbS0PJe1SHunbyXjJ/BqG1z9bFjGUIvTg==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.5.1
+      import-local: 3.1.0
+      jest-cli: 27.5.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
 
   /jest@27.4.7(ts-node@10.9.1):
@@ -4784,7 +4935,7 @@ packages:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.4.7(ts-node@10.9.1)
+      jest: 27.4.7
       jest-util: 27.5.1
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -5098,6 +5249,19 @@ packages:
       utf-8-validate:
         optional: true
     dev: true
+
+  /ws@8.14.2:
+    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /xml-name-validator@3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 2.4.2
       jest:
         specifier: 27.4.7
-        version: 27.4.7
+        version: 27.4.7(ts-node@10.9.1)
       semantic-release:
         specifier: ^18.0.1
         version: 18.0.1
@@ -650,51 +650,6 @@ packages:
       jest-message-util: 27.5.1
       jest-util: 27.5.1
       slash: 3.0.0
-    dev: true
-
-  /@jest/core@27.5.1:
-    resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/reporters': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 17.0.21
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 27.5.1
-      jest-config: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-message-util: 27.5.1
-      jest-regex-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1
-      jest-runtime: 27.5.1
-      jest-snapshot: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
-      jest-watcher: 27.5.1
-      micromatch: 4.0.5
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
     dev: true
 
   /@jest/core@27.5.1(ts-node@10.9.1):
@@ -2919,36 +2874,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@27.5.1:
-    resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/types': 27.5.1
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      import-local: 3.1.0
-      jest-config: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
-      prompts: 2.4.2
-      yargs: 16.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
-    dev: true
-
   /jest-cli@27.5.1(ts-node@10.9.1):
     resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2976,46 +2901,6 @@ packages:
       - canvas
       - supports-color
       - ts-node
-      - utf-8-validate
-    dev: true
-
-  /jest-config@27.5.1:
-    resolution: {integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.9
-      '@jest/test-sequencer': 27.5.1
-      '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.22.9)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1
-      jest-environment-node: 27.5.1
-      jest-get-type: 27.5.1
-      jest-jasmine2: 27.5.1
-      jest-regex-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runner: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 27.5.1
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -3520,27 +3405,6 @@ packages:
       jest-util: 29.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: true
-
-  /jest@27.4.7:
-    resolution: {integrity: sha512-8heYvsx7nV/m8m24Vk26Y87g73Ba6ueUd0MWed/NXMhSZIm62U/llVbS0PJe1SHunbyXjJ/BqG1z9bFjGUIvTg==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 27.5.1
-      import-local: 3.1.0
-      jest-cli: 27.5.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
     dev: true
 
   /jest@27.4.7(ts-node@10.9.1):
@@ -4937,7 +4801,7 @@ packages:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.4.7
+      jest: 27.4.7(ts-node@10.9.1)
       jest-util: 27.5.1
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
This PR:

- adds the ability to use a websocket server for handling Bridg requests
   - can be configured simply by passing a ws url as your generator api:
   ```ts
   generator bridg {
     api = "ws://localost:3000/api/bridg"
     pulse = true
   }
   ```

- adds support for the [Prisma pulse extension](https://www.prisma.io/docs/data-platform/pulse/what-is-pulse), for listening to realtime data changes.  to use this feature, you must:
     -  use a websocket api
     - pass `pulse = true` in the bridg generator 
     - extend your prisma client with pulse before passing it to Bridg for handling an incoming request:
     ```ts
     const db = new PrismaClient().$extends.withPulse({ apiKey: PULSE_API_KEY })) as unknown as PrismaClient;
    ```

An example socket server implementation can be viewed here:
https://github.com/JoeRoddy/pulse-chat-demo/blob/main/src/pages/api/socket.ts

In the future, I would like to simplify this to hide some of these complexities of managing subscriptions and replying to websocket messages.

- adds a test suite to validate pulse subscriptions obey Bridg rules